### PR TITLE
Fix server static asset path

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,6 +9,8 @@ dotenv.config(); // carregue variáveis de .env
 
 const app = express();
 app.use(express.json());
+// Serve arquivos estáticos da pasta "public"
+app.use(express.static('public'));
 app.use(express.static(path.join(__dirname, 'public')));
 
 // cria pool de conexões


### PR DESCRIPTION
## Summary
- serve static files from `public` directory

## Testing
- `npm start` *(fails: Missing DB but server runs)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845cbd924e48320a44323807d8c5ce9