### PR TITLE
Fix static middleware duplication

### DIFF
--- a/server.js
+++ b/server.js
@@ -10,7 +10,6 @@ dotenv.config(); // carregue variáveis de .env
 const app = express();
 app.use(express.json());
 // Serve arquivos estáticos da pasta "public"
-app.use(express.static('public'));
 app.use(express.static(path.join(__dirname, 'public')));
 
 // cria pool de conexões


### PR DESCRIPTION
## Summary
- remove redundant `express.static` call in `server.js`

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6846c0b6bde48320a74f6df81491821f