### PR TITLE
Restore .env.example template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+DB_HOST=localhost
+DB_USER=root
+DB_PASSWORD=yourpassword
+DB_NAME=unireservas
+PORT=3000


### PR DESCRIPTION
## Summary
- add `.env.example` to show required environment variables

## Testing
- `npm start` *(fails: Access denied for user 'root'@'localhost' (using password: YES))*

------
https://chatgpt.com/codex/tasks/task_e_684714276f8c832085f24af270d76132