### PR TITLE
Use external CSS for unified styling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,18 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>UniReservas</title>
-  <style>
-    body { font-family: Arial, sans-serif; margin: 20px; }
-    .tabs { display: flex; margin-bottom: 10px; }
-    .tab { margin-right: 10px; padding: 5px 10px; border: 1px solid #ccc; cursor: pointer; }
-    .active { background: #eee; }
-    .content { display: none; }
-    .show { display: block; }
-    label { display: block; margin: 5px 0; }
-    .mesas-table { width: 100%; border-collapse: collapse; margin-top: 5px; }
-    .mesas-table th, .mesas-table td { border: 1px solid #ccc; padding: 4px 8px; text-align: left; }
-    .mesa-toggle-btn { background: #008cba; color: #fff; border: none; padding: 4px 8px; cursor: pointer; border-radius: 4px; }
-  </style>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <div class="tabs">
@@ -29,7 +18,7 @@
     <label>Horário: <select id="horarioSelect"></select></label>
     <div id="mesasSection">
       <button id="toggleMesasBtn" class="mesa-toggle-btn">▼ Mesas</button>
-      <div id="mesasContainer" style="display:none;">
+      <div id="mesasContainer">
         <table class="mesas-table">
           <thead>
             <tr><th>Número</th><th>Disponível</th><th>Capacidade</th></tr>

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,13 @@
+body { font-family: Arial, sans-serif; margin: 20px; }
+.tabs { display: flex; margin-bottom: 10px; }
+.tab { margin-right: 10px; padding: 5px 10px; border: 1px solid #ccc; cursor: pointer; border-radius: 4px 4px 0 0; background: #f9f9f9; }
+.active { background: #eee; }
+.content { display: none; border: 1px solid #ccc; border-radius: 0 4px 4px 4px; padding: 10px; }
+.show { display: block; }
+label { display: block; margin: 8px 0 4px; font-weight: bold; }
+input, select { padding: 4px 8px; border: 1px solid #ccc; border-radius: 4px; margin-bottom: 8px; box-sizing: border-box; }
+.mesas-table { width: 100%; border-collapse: collapse; margin-top: 5px; }
+.mesas-table th, .mesas-table td { border: 1px solid #ccc; padding: 4px 8px; text-align: left; }
+.mesa-toggle-btn, button { background: #008cba; color: #fff; border: none; padding: 6px 12px; cursor: pointer; border-radius: 4px; }
+.mesa-toggle-btn:hover, button:hover { background: #0079a1; }
+#mesasContainer { display: none; }


### PR DESCRIPTION
## Summary
- move inline styles into `public/style.css`
- link `style.css` from `index.html`
- add consistent modern styling for labels, inputs and buttons

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684756e09be0832096e62f74b517bd07