### PR TITLE
Fix missing styles on new client form

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -180,7 +180,7 @@ document.getElementById('clienteSelect').addEventListener('change', e => {
 
 document.getElementById('toggleNovoCliente').addEventListener('click', () => {
     const form = document.getElementById('cliente-form');
-    form.style.display = form.style.display === 'block' ? 'none' : 'block';
+    form.classList.toggle('show');
 });
 
 document.getElementById('salvarCliente').addEventListener('click', async () => {
@@ -200,7 +200,7 @@ document.getElementById('salvarCliente').addEventListener('click', async () => {
             document.getElementById('clienteSelect').value = c.id_cliente;
             selectedCliente = c;
             document.getElementById('clienteNext').disabled = false;
-            document.getElementById('cliente-form').style.display = 'none';
+            document.getElementById('cliente-form').classList.remove('show');
         } else {
             toast(c.message || 'Erro ao cadastrar');
         }

--- a/public/index.html
+++ b/public/index.html
@@ -20,9 +20,18 @@
             </div>
             <button id="toggleNovoCliente">Cadastrar Novo Cliente</button>
             <div id="cliente-form" class="novo-cliente">
-                <input id="novoNome" placeholder="Nome" type="text">
-                <input id="novoTelefone" placeholder="Telefone" type="text">
-                <input id="novoEmail" placeholder="Email" type="email">
+                <div class="field">
+                    <label for="novoNome">Nome</label>
+                    <input id="novoNome" placeholder="Nome" type="text">
+                </div>
+                <div class="field">
+                    <label for="novoTelefone">Telefone</label>
+                    <input id="novoTelefone" placeholder="Telefone" type="text">
+                </div>
+                <div class="field">
+                    <label for="novoEmail">Email</label>
+                    <input id="novoEmail" placeholder="Email" type="email">
+                </div>
                 <button id="salvarCliente">Cadastrar</button>
             </div>
             <div class="actions">


### PR DESCRIPTION
## Summary
- style the new client form inputs using existing `.field` classes
- toggle the form using the `show` CSS class

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848ebfb85e083209c7efe3c38f25456