### PR TITLE
Set table button text color

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -117,6 +117,7 @@ async function carregarLayout() {
                 btn.className = 'table-btn available';
                 btn.title = `Número ${m.id_mesa}`;
                 btn.textContent = m.capacidade;
+                btn.style.color = 'black';
                 btn.addEventListener('click', () => {
                     document.querySelectorAll('.table-btn').forEach(b => b.classList.remove('selected'));
                     btn.classList.add('selected');


### PR DESCRIPTION
## Summary
- make table capacity text appear in black color

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6848f65fd6688320b3f0ac227d18c525