### PR TITLE
Add CRUD for pagamentos in admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ A aplicação iniciará na porta definida na variável `PORT` e exibirá `Servid
 - `PUT /api/reservas/:id` `{ horario?, numPessoas?, preferenciaLocalizacao?, statusPagamento? }`
 - `DELETE /api/reservas/:id`
 - `GET /api/pagamentos`
+- `POST /api/pagamentos` `{ reservaId, valor, metodo?, status? }`
+- `PUT /api/pagamentos/:id` `{ reservaId?, valor?, metodo?, status? }`
+- `DELETE /api/pagamentos/:id`
 
 ### Exemplo de Pagamento
 O pagamento é simulado. Cartões que começam com `4` são aprovados; qualquer outro número resulta em falha e a transação é revertida.

--- a/controller/pagamentoController.js
+++ b/controller/pagamentoController.js
@@ -12,4 +12,34 @@ router.get('/', async (req, res) => {
   }
 });
 
+router.post('/', async (req, res) => {
+  try {
+    const pagamento = await pagamentoService.criar(req.body);
+    res.status(201).json(pagamento);
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+  }
+});
+
+router.put('/:id', async (req, res) => {
+  try {
+    const pagamento = await pagamentoService.atualizar(req.params.id, req.body);
+    res.json(pagamento);
+  } catch (err) {
+    console.error(err);
+    res.status(400).json({ message: err.message });
+  }
+});
+
+router.delete('/:id', async (req, res) => {
+  try {
+    await pagamentoService.remover(req.params.id);
+    res.sendStatus(204);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Erro ao remover pagamento' });
+  }
+});
+
 module.exports = router;

--- a/dao/PagamentoDAO.js
+++ b/dao/PagamentoDAO.js
@@ -1,8 +1,33 @@
-const { query } = require('../config/database');
+const { query, pool } = require('../config/database');
 
 class PagamentoDAO {
   async listar() {
     return query('SELECT * FROM PAGAMENTO');
+  }
+
+  async inserir({ reservaId, valor, metodo, status }) {
+    const [result] = await pool.execute(
+      'INSERT INTO PAGAMENTO (reserva_id, valor, metodo, status, data_processamento) VALUES (?, ?, ?, ?, NOW())',
+      [reservaId, valor, metodo, status]
+    );
+    return { id_pagamento: result.insertId, reservaId, valor, metodo, status };
+  }
+
+  async atualizar(id, { reservaId, valor, metodo, status }) {
+    await query(
+      `UPDATE PAGAMENTO
+         SET reserva_id = COALESCE(?, reserva_id),
+             valor = COALESCE(?, valor),
+             metodo = COALESCE(?, metodo),
+             status = COALESCE(?, status)
+       WHERE id_pagamento = ?`,
+      [reservaId, valor, metodo, status, id]
+    );
+    return { id_pagamento: id, reservaId, valor, metodo, status };
+  }
+
+  async remover(id) {
+    await query('DELETE FROM PAGAMENTO WHERE id_pagamento = ?', [id]);
   }
 }
 

--- a/public/admin.js
+++ b/public/admin.js
@@ -285,6 +285,57 @@ async function deleteReserva(row) {
     }
 }
 
+async function addPagamento() {
+    const reservaId = prompt('ID da reserva:');
+    if (!reservaId) return;
+    const valor = prompt('Valor:');
+    if (!valor) return;
+    const metodo = prompt('Método:', 'CARTAO');
+    if (!metodo) return;
+    const status = prompt('Status:', 'PENDENTE');
+    if (!status) return;
+    try {
+        await fetchJSON('/api/pagamentos', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ reservaId, valor, metodo, status })
+        });
+        toast('Pagamento criado');
+        init();
+    } catch (e) {
+        toast('Erro ao criar pagamento');
+    }
+}
+
+async function editPagamento(row) {
+    const reservaId = prompt('ID da reserva:', row.reserva_id);
+    const valor = prompt('Valor:', row.valor);
+    const metodo = prompt('Método:', row.metodo);
+    const status = prompt('Status:', row.status);
+    try {
+        await fetchJSON(`/api/pagamentos/${row.id_pagamento}`, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ reservaId, valor, metodo, status })
+        });
+        toast('Pagamento atualizado');
+        init();
+    } catch (e) {
+        toast('Erro ao atualizar pagamento');
+    }
+}
+
+async function deletePagamento(row) {
+    if (!confirm('Excluir pagamento?')) return;
+    try {
+        await fetchJSON(`/api/pagamentos/${row.id_pagamento}`, { method: 'DELETE' });
+        toast('Pagamento removido');
+        init();
+    } catch (e) {
+        toast('Erro ao remover pagamento');
+    }
+}
+
 async function renderClientes(container) {
     const data = await fetchJSON('/api/clientes');
     container.appendChild(buildTable(data, {
@@ -327,7 +378,12 @@ async function renderReservas(container) {
 
 async function renderPagamentos(container) {
     const data = await fetchJSON('/api/pagamentos');
-    container.appendChild(buildTable(data, { title: 'Pagamentos' }));
+    container.appendChild(buildTable(data, {
+        title: 'Pagamentos',
+        onAdd: addPagamento,
+        onEdit: editPagamento,
+        onDelete: deletePagamento
+    }));
 }
 
 async function init() {

--- a/service/PagamentoService.js
+++ b/service/PagamentoService.js
@@ -4,6 +4,24 @@ class PagamentoService {
   async listar() {
     return pagamentoDAO.listar();
   }
+
+  async criar(data) {
+    const { reservaId, valor, metodo = 'CARTAO', status = 'PENDENTE' } = data;
+    if (!reservaId || valor == null) throw new Error('Dados incompletos');
+    return pagamentoDAO.inserir({ reservaId, valor, metodo, status });
+  }
+
+  async atualizar(id, data) {
+    const { reservaId, valor, metodo, status } = data;
+    if (reservaId == null && valor == null && !metodo && !status) {
+      throw new Error('Nada para atualizar');
+    }
+    return pagamentoDAO.atualizar(id, { reservaId, valor, metodo, status });
+  }
+
+  async remover(id) {
+    await pagamentoDAO.remover(id);
+  }
 }
 
 module.exports = new PagamentoService();


### PR DESCRIPTION
## Summary
- implement insert/update/delete on pagamentos DAO
- expose pagamento CRUD in service and controller
- enable admin frontend to create, edit and delete pagamentos
- document payment endpoints in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6849f30e50648320861460d150c765d4